### PR TITLE
Add `doubleshot jar` command.

### DIFF
--- a/examples/hello_world/Doubleshot
+++ b/examples/hello_world/Doubleshot
@@ -5,6 +5,8 @@ Doubleshot.new do |config|
   config.project = "hello_world"
   config.version = "0.1.0"
 
+  config.java_main = "org.sam.doubleshot.examples.hello_world.HelloWorld"
+
   config.gemspec do |spec|
     spec.summary        = "A simple Hello World sample."
     spec.description    = <<-DESCRIPTION

--- a/examples/hello_world/ext/java/HelloWorld.java
+++ b/examples/hello_world/ext/java/HelloWorld.java
@@ -1,3 +1,8 @@
+// Build with:
+//   doubleshot jar
+// Execute with:
+//   java -jar target/hello_world.jar
+
 package org.sam.doubleshot.examples.hello_world;
 
 public class HelloWorld {

--- a/lib/doubleshot/commands/jar.rb
+++ b/lib/doubleshot/commands/jar.rb
@@ -1,7 +1,49 @@
 class Doubleshot::CLI::Commands::Jar < Doubleshot::CLI
+
   def self.summary
     <<-EOS.margin
-      TODO
+      Package your project as a JAR.
     EOS
+  end
+
+  def self.options
+    Options.new do |options|
+      options.banner = "Usage: doubleshot jar"
+      options.separator ""
+      options.separator "Options"
+
+      options.test = true
+      options.on "--no-test", "Disable testing as a build prerequisite." do
+        options.test = false
+      end
+
+      options.separator ""
+      options.separator "Summary: #{summary}"
+    end
+  end
+
+  def self.start(args)
+    options = self.options.parse!(args)
+    doubleshot = Doubleshot::current
+
+    Doubleshot::CLI::Commands::Build.start([])
+
+    unless Pathname::glob(doubleshot.config.source.java + "**/*.java").empty?
+      target = doubleshot.config.target
+
+      jarfile = (target + "#{doubleshot.config.project}.jar")
+      jarfile.delete if jarfile.exist?
+
+      ant.jar jarfile: jarfile, basedir: target do
+        manifest{
+          attribute(:name => "Main-Class", :value => doubleshot.config.java_main)
+        }
+        doubleshot.lockfile.jars.each do |jar|
+          zipfileset src: jar.path.expand_path, excludes: "META-INF/*.SF"
+        end
+      end
+    end
+
+    return 0
   end
 end

--- a/lib/doubleshot/configuration.rb
+++ b/lib/doubleshot/configuration.rb
@@ -70,6 +70,11 @@ class Doubleshot
     # The default is "target".
     EOS
 
+    JAVA_MAIN_MESSAGE     = <<-EOS.margin
+    # Class to use for Ant's Main-Class attribute for
+    # a manifest. The default is "org.jruby.Main".
+    EOS
+
     WHITELIST_MESSAGE     = <<-EOS.margin
     # List of file extensions within source folders
     # that will be included during packaging.
@@ -114,12 +119,16 @@ class Doubleshot
     # NOTE: The above won't appear in your Doubleshot
     # file as it's added during the build process for you.
     EOS
+
+    attr_accessor :java_main
+
     def initialize
       @defaults                    = {}
       @gemspec                     = Gem::Specification.new
       @gemspec.platform            = Gem::Platform.new("java")
       @source                      = SourceLocations.new
       @target                      = default :target, Pathname("target")
+      @java_main                   = default :java_main, "org.jruby.Main"
 
       @runtime_dependencies        = Dependencies.new
       @development_dependencies    = Dependencies.new

--- a/test/configuration_spec.rb
+++ b/test/configuration_spec.rb
@@ -175,6 +175,12 @@ describe Doubleshot::Configuration do
       end
     end
 
+    describe "java_main" do
+      it 'must default to "org.jruby.Main"' do
+        @config.java_main.must_equal "org.jruby.Main"
+      end
+    end
+
     describe "paths" do
       it "must return a readonly collection of paths" do
         @config.paths.must_be_kind_of Doubleshot::ReadonlyCollection


### PR DESCRIPTION
Added a @config.java_main variable for use in the Doubleshot file to
specify the class containing the main method. Defaults to
org.jruby.Main.

Updated the Hello World example for use with the new `doubleshot jar`
command.

Addresses sam/doubleshot#33.
