### PR TITLE
Added a doubleshot_test.pid file to Pathname::pwd

### DIFF
--- a/lib/doubleshot/commands/test.rb
+++ b/lib/doubleshot/commands/test.rb
@@ -35,7 +35,7 @@ class Doubleshot::CLI::Commands::Test < Doubleshot::CLI
   def self.start(args)
     options = self.options.parse!(args)
 
-    @@pid_file = Pathname::pwd + "doubleshot_test.pid"
+    @@pid_file = Pathname::pwd + ".doubleshot_test.pid"
     if !@@pid_file.nil? && @@pid_file.exist? && !options.force_tests
       puts "doubleshot_test.pid exists: Are you running tests elsewhere? (Use --force to override.)"
       exit 1


### PR DESCRIPTION
Added a doubleshot_test.pid file to Pathname::pwd so two test processes can't run simulataneously.

Couldn't use tmp/test.pid as originally suggested because our testing Helper::tmp method would delete it during tests.

closes sam/doubleshot#45
