### PR TITLE
Update doubleshot_test.pid exists message.

### DIFF
--- a/lib/doubleshot/commands/test.rb
+++ b/lib/doubleshot/commands/test.rb
@@ -37,7 +37,7 @@ class Doubleshot::CLI::Commands::Test < Doubleshot::CLI
 
     @@pid_file = Pathname::pwd + ".doubleshot_test.pid"
     if !@@pid_file.nil? && @@pid_file.exist? && !options.force_tests
-      puts "doubleshot_test.pid exists: Are you running tests elsewhere? (Use --force to override.)"
+      puts ".doubleshot_test.pid exists: Are you running tests elsewhere? (Use --force to override.)"
       exit 1
     end
 


### PR DESCRIPTION
Forgot to make it say .doubleshot_test.pid exists when I turned the pidfile into a dotfile.

Part of sam/doubleshot#45.
