### PR TITLE
Build should skip compilation if config.source.java doesn't exist.

### DIFF
--- a/Doubleshot
+++ b/Doubleshot
@@ -19,7 +19,7 @@ Doubleshot.new do |config|
     config.mvn_repository "http://maven.mirrors.travis-ci.org/nexus/content/shadows/central-m1/"
     config.mvn_repository "http://maven.mirrors.travis-ci.org/nexus/content/repositories/central/"
   end
-  
+
   config.mvn_repository "https://nexus.codehaus.org/content/groups/public/"
   config.mvn_repository "https://oss.sonatype.org/content/groups/public/"
   config.mvn_repository "http://mirrors.ibiblio.org/pub/mirrors/maven2"

--- a/examples/call_java/Doubleshot
+++ b/examples/call_java/Doubleshot
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+Doubleshot.new do |config|
+
+  config.project = "call_java"
+  config.version = "0.1.0"
+
+  config.jar "com.fasterxml.jackson.core:jackson-core:2.0.6"
+
+  config.gemspec do |spec|
+    spec.summary        = "An example using Ruby to call a Java library."
+    spec.description    = <<-DESCRIPTION
+This example shows that you can use Doubleshot for managing
+your Java dependencies, even if you don't have any Java code
+of your own to compile.
+DESCRIPTION
+
+    spec.homepage       = "https://github.com/sam/doubleshot/blob/master/examples/call_java"
+    spec.author         = "Sam Smoot"
+    spec.email          = "ssmoot@gmail.com"
+    spec.license        = "MIT-LICENSE"
+  end
+
+end

--- a/examples/call_java/Doubleshot.lock
+++ b/examples/call_java/Doubleshot.lock
@@ -1,0 +1,4 @@
+---
+JARS:
+- com.fasterxml.jackson.core:jackson-core:jar:2.0.6
+GEMS: []

--- a/examples/call_java/lib/call_java.rb
+++ b/examples/call_java/lib/call_java.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env jruby
+
+require "doubleshot/setup"
+
+java_import com.fasterxml.jackson.core.JsonFactory
+
+puts com.fasterxml.jackson.core.JsonFactory.new.inspect

--- a/examples/jackson/Doubleshot
+++ b/examples/jackson/Doubleshot
@@ -10,7 +10,7 @@ Doubleshot.new do |config|
 
   config.gem "perfer", "= 0.2.0"
   config.gem "json"
-  
+
   config.gemspec do |spec|
     spec.summary        = "A simple Jackson vs json-jruby benchmark."
     spec.description    = <<-DESCRIPTION

--- a/lib/doubleshot/commands/build.rb
+++ b/lib/doubleshot/commands/build.rb
@@ -39,8 +39,6 @@ class Doubleshot::CLI::Commands::Build < Doubleshot::CLI
       doubleshot.config.target.rmtree
     end
 
-    compiler = Doubleshot::Compiler.new(doubleshot.config.source.java, doubleshot.config.target)
-
     if doubleshot.config.project == "doubleshot"
       puts "Bootstrapping Doubleshot build with Maven..."
       doubleshot.bootstrap!
@@ -49,22 +47,26 @@ class Doubleshot::CLI::Commands::Build < Doubleshot::CLI
       doubleshot.setup!
     end
 
-    if options.classpath.empty?
-      doubleshot.classpath
-    else
-      options.classpath
-    end.each do |path|
-      compiler.classpath << path
-    end
+    if doubleshot.config.source.java.exist?
+      compiler = Doubleshot::Compiler.new(doubleshot.config.source.java, doubleshot.config.target)
 
-    puts "[INFO] Using #{compiler.classpath}"
-    puts
+      if options.classpath.empty?
+        doubleshot.classpath
+      else
+        options.classpath
+      end.each do |path|
+        compiler.classpath << path
+      end
 
-    if compiler.pending? || !options.conditional
-      puts "Compiling..."
-      compiler.build!
-    else
-      puts "Conditional build: No source changes."
+      puts "[INFO] Using #{compiler.classpath}"
+      puts
+
+      if compiler.pending? || !options.conditional
+        puts "Compiling..."
+        compiler.build!
+      else
+        puts "Conditional build: No source changes."
+      end
     end
 
     return 0


### PR DESCRIPTION
Also added an example to test with.

fixes sam/doubleshot#62
