### PR TITLE
Doubleshot ignores classifier for jar dependencies

### DIFF
--- a/lib/doubleshot/dependencies/jar_dependency.rb
+++ b/lib/doubleshot/dependencies/jar_dependency.rb
@@ -42,7 +42,7 @@ class Doubleshot
       end
 
       def to_s(long_form = false)
-        @name
+        @classifier.blank? ? @name : "#{@group}:#{@artifact}:#{@packaging}:#{@classifier}:#{@version}"
       end
 
       def path=(path)


### PR DESCRIPTION
This is because jar_resolver passes the "to_s" version of jar dependency to Aether. 
(See doubleshot/resolver/jar_resolver.rb:15): 

``` ruby
#...
   def resolve!(dependencies)
        dependencies.each do |dependency|
          @aether.add_artifact dependency.to_s
        end
#...
```

As a result aether cannot find the required artifact (it tries to fetch the version without classifier).
