### PR TITLE
Fixing a bug caused by YAML::load(Pathname).

### DIFF
--- a/lib/doubleshot.rb
+++ b/lib/doubleshot.rb
@@ -181,7 +181,7 @@ class Doubleshot
     if classpath_cache.exist?
       # We survived the cleanup checks, go ahead and just load
       # the cached version of your JARs.
-      cached_paths = YAML::load(classpath_cache)
+      cached_paths = YAML::load(classpath_cache.read)
 
       lockfile.jars.each do |jar|
         jar.path = cached_paths[jar.to_s]


### PR DESCRIPTION
The fix is to call Pathname#read and pass the contents of the file to
YAML::load. Passing the pathname itself caused a strange infinite loop
that consumed all available memory and processor, which I haven't been
able to reproduce except with that classpath cache file.
